### PR TITLE
docs(ch08): align content provider chapter with latest Android guidance

### DIFF
--- a/md/chapter08_content_providers.md
+++ b/md/chapter08_content_providers.md
@@ -2,6 +2,8 @@
 
 任何应用程序都可以通过文件系统或数据库存储文件，其它应用程序可以来读取这些文件（当然可能需要某些访问权限的设置）。在安卓上，应用程序的所有数据对其他应用程序都是私有的，其他应用只有通过设置权限才可以获取数据。安卓系统提供了几种本地数据的存储方式。如果要将这些数据共享的话，安卓通过定义内容提供器能够把私有数据公开给其他应用程序。内容提供器是一种为了开放应用程序的数据读写，具有访问权限的可选组件，可以通过这个组件实现私有数据的读写访问。内容提供器提供了请求和修改数据的标准语法和读取返回数据的标准机制。安卓为标准的数据类型提供了一些内容提供器，如图像、视频和音频文件，以及个人通讯录信息。安卓提供几种持久化应用程序数据的选择，具体选择那种方式依赖于具体的需求，例如数据应该是应用程序私有的还是共享的，或者数据所需要的存储空间等。
 
+> 版本说明（截至 2026 年）：本章按当前主流实践更新，重点兼容 Android 6.0+ 运行时权限模型，以及 Android 12+ 组件导出规则；示例中的旧接口会给出迁移建议。
+
 ## 基本概念
 
 一般情况下安卓应用程序的数据是私有的，其他应用程序不具有访问的权限。但很多时候安卓应用程序的服务包括数据的服务，某些数据希望开放给其他安卓应用程序使用。安卓系统解决这个问题的方法是定义一个通用的、格式统一的数据访问接口，使其他应用程序可以通过调用这个接口提供的方法，访问和修改数据。内容提供器是安卓系统提供给用户的一个接口，用于管理如何访问应用程序私有数据的存储库。这里的数据包括结构化存储数据和非结构化存储数据。
@@ -159,7 +161,7 @@ API 和组件对应用数据存储层的访问（如图 1 所示），其中包�
 
   - 通过实现 AbstractThreadedSyncAdapter，将应用数据与服务器同步
 
-  - 使用 CursorLoader 在界面中加载数据
+  - 使用异步查询机制在界面中加载数据（如 `androidx.loader.content.CursorLoader`，或基于协程/Flow 的数据层）
 
 <table>
 <tbody>
@@ -276,12 +278,15 @@ URI，为了从内容提供器中检索数据，需要两个基本步骤：
 
 （1）给提供器申请读访问权限
 
-能够从内容提供器中获取数据的前提，首先是所访问的内容提供器允许其他应用程序的读访问。从内容提供器中获取数据，应用程序需要“读权限”。这个权限不能在应用程序运行时设置，需要在应用程序的Manifest文件中里预先声明需要的权限元素。如果指定了这个元素，当用户安装这个应用程序时，系统会隐式地付给其相应的权限。
+能够从内容提供器中获取数据的前提，首先是所访问的内容提供器允许其他应用程序的读访问。从内容提供器中获取数据，应用程序需要“读权限”。在现代 Android 中，权限通常分为 normal 和 dangerous：normal 权限在安装时自动授予；dangerous 权限除了在 Manifest 中声明，还必须在运行时向用户申请。
 
-Manifest文件中的权限声明元素是\<uses-permission\>元素，权限的值从将要访问内容提供器所定义的权限中选择，根据需求指定准确的权限名称。例如，用户字典的内容提供器的定义了权限android.permission.READ\_USER\_DICTIONARY，作为其可读取的权限。如果应用程序需要从用户字典的内容提供器读取数据，就需要在其Manifest文件里声明用户字典的内容提供器的可读取，代码如下：
+> 版本提示（Android 6.0+）：如果所需权限属于运行时权限（dangerous），仅在 Manifest 声明还不够，还必须在运行时向用户申请授权。
 
-> \<uses-permission android:name="
-> android.permission.READ\_USER\_DICTIONARY" /\>
+Manifest文件中的权限声明元素是\<uses-permission\>元素，权限的值从将要访问内容提供器所定义的权限中选择，根据需求指定准确的权限名称。例如，联系人提供器读取权限为 `android.permission.READ_CONTACTS`，需要在 Manifest 中声明：
+
+> \<uses-permission android:name="android.permission.READ\_CONTACTS" /\>
+
+> 版本提示：`READ_USER_DICTIONARY` 在 Android 6.0（API 23）起仅面向输入法（IME）或拼写检查器，普通应用不应再把它作为通用示例权限。
 
 码 8‑4
 
@@ -538,10 +543,9 @@ getType() 方法，返回该列的数据类型的值。
 如果需要插入、更新或者删除数据，首先要考虑的还是权限的问题。需要为内容提供器定义不同的数据访问权限，以便其他应用能够访问其提供的数据。权限的定义可以保证用户能够知道应用程序中的哪些数据可以访问。基于内容提供器提供的说明，其他的应用程序可以根据自身的需求来申请权限去访问内容提供器，最后用户在安装此应用时会看到该应用请求获得的权限。如果包含内容提供器的应用没有指定任何权限，其他的应用程序是无法访问该内容提供器的数据的。但是无论是否指定了权限，包含内容提供器应用的其他组件拥有对该内容提供器的完全读写权限。
 
 正如上面所说，
-内容提供器在用户字典中使用android.permission.WRITE\_USER\_DICTIONARY权限来控制对数据的插入，更新和删除。为获得访问内容提供器的权限，应用程序在Manifest文件中需要使用uses-permission|标签。当安卓包管理器安装应用时，用户必须批准应用程序的所有权限请求。如果用户允许了，包管理器会继续安装流程；如果用户不允许，包管理器会终止安装。例如，在应用程序中插入、更新或者删除用户字典内容提供器的数据，需要在Manifest文件中声明android.permission.WRITE\_USER\_DICTIONARY权限，例如：
+内容提供器在用户字典中使用android.permission.WRITE\_USER\_DICTIONARY权限来控制对数据的插入，更新和删除。为获得访问内容提供器的权限，应用程序在Manifest文件中需要使用\<uses-permission\>标签；对于危险权限，还需要在运行时向用户申请授权。需要注意的是，用户词典相关权限在新版本系统中不再适合作为普通第三方应用的通用示例。
 
-\<uses-permission
-android:name="android.permission.WRITE\_USER\_DICTIONARY" /\>
+\<uses-permission android:name="android.permission.WRITE\_USER\_DICTIONARY" /\>
 
 码 8‑11
 
@@ -864,7 +868,7 @@ Intent 中设置标记，从而授予临时权限：
   - 写入权限： FLAG\_GRANT\_WRITE\_URI\_PERMISSION
 
 注意：如果内容 URI 中包含提供程序的授权，这些标记不提供对提供程序的常规读取或写入访问权限。访问权限仅适用于 URI 本身。提供程序通过使用
-\<provider\> 元素的 android:grantUriPermission 属性和 \<provider\> 元素的
+\<provider\> 元素的 android:grantUriPermissions 属性和 \<provider\> 元素的
 \<grant-uri-permission\> 子元素，在其清单文件中定义内容 URI 的 URI 权限。权限概览指南更加详细地说明了 URI
 权限机制。
 
@@ -872,8 +876,7 @@ Intent 中设置标记，从而授予临时权限：
 权限，也可以在联系人提供程序中检索联系人的数据。在向联系人发送电子生日祝福的应用中，可能希望执行此操作。相较于通过请求
 READ\_CONTACTS 访问用户的所有联系人及其信息，可能更愿意让用户控制应用所使用的联系人。为此需完成以下过程：
 
-  - (1)应用会使用 startActivityForResult() 方法发送包含 ACTION\_PICK 操作和
-    CONTENT\_ITEM\_TYPE“联系人”MIME 类型的 Intent。
+  - (1)应用应使用 Activity Result API（`registerForActivityResult`）而不是 `startActivityForResult()`；例如可注册 `ActivityResultContracts.PickContact`。
 
   - (2)由于此 Intent 与“联系人”应用“选择”Activity 的 Intent 过滤器相匹配，因此活动会显示在前台。
 
@@ -882,9 +885,7 @@ READ\_CONTACTS 访问用户的所有联系人及其信息，可能更愿意让�
     FLAG\_GRANT\_READ\_URI\_PERMISSION。这些标记会为应用授予 URI 权限，以便读取内容 URI
     所指向联系人的数据。然后，选择活动会调用 finish()，将控制权交还给应用。
 
-  - (4)活动会返回至前台，并且系统会调用此活动的 onActivityResult()
-    方法。此方法会收到“联系人”应用中选择活动所创建的结果
-    Intent。
+  - (4)用户返回后，结果会在注册的回调中返回（而不是 `onActivityResult()`），回调拿到联系人 URI 并继续读取数据。
 
   - (5)通过来自结果 Intent 的内容
     URI，可以读取来自联系人提供程序的联系人数据，即使未在清单文件中请求对该提供程序的永久读取访问权限。可以获取联系人的生日信息或其电子邮件地址，然后发送电子祝福。
@@ -1284,7 +1285,9 @@ vnd.android.cursor.item/vnd.com.example.provider.table1
   - 如果某个方法调用用于打开或创建设备内部存储的文件或 SQLite
     数据库，则该调用可能会向所有其他应用同时授予读取和写入访问权限。如果将内部文件或数据库用作提供程序的存储区，并向其授予“可全局读取”或“可全局写入”访问权限，则在清单文件中为提供程序设置的权限不会保护数据。在内部存储中，文件和数据库的默认访问权限是“私有”，并且不应该为提供程序的存储区更改此权限。
 
-如果要使用内部文件或数据库作为内容提供器的数据源，必须在Manifest文件中设置权限，把其访问权限设为world-readable或world-writeable，这些数据将不再受到保护。默认情况下内部储器文件和数据库的访问权限是“private”，对于内容提供器也不应该改变。如果要使用内容提供器的权限来控制对数据的访问，就应该将数据存储在内部文件，SQLite数据库，或云的数据中（例如，在远程服务器上），并保持文件和数据库的私有存储访问权限，怎样进行内容提供器的权限控制呢？如果不做任何权限设置，所有的应用程序可以读取或写入内容提供器，即使这些数据的存储访问权限是私有的，因为默认情况下内容提供器没有的权限集。内容提供器的权限集需要在Manifest中，使用内容提供器的属性和子元素来设置。在这里可以设置应用于整个内容提供器、特定的表、单一的记录或满足某些条件权限。在Manifest文件中，可以使用
+如果要使用内部文件或数据库作为内容提供器的数据源，不应把底层存储改为 world-readable 或 world-writeable。默认情况下内部存储文件和数据库的访问权限是“private”，内容提供器场景下也应保持该默认值。要使用内容提供器权限来控制访问，应通过 \<provider\> 的权限属性和子元素进行控制，而不是放宽底层文件权限。  
+
+如果不做权限设置且提供器被导出，其他应用可能读取或写入内容提供器数据。因此，内容提供器的权限集需要在Manifest中，使用内容提供器的属性和子元素来设置。在这里可以设置应用于整个内容提供器、特定的表、单一的记录或满足某些条件权限。在Manifest文件中，可以使用
 \<permission\>元素为内容提供器定义一个或多个访问权限。为了这些权限的唯一性，可以用Java包名的方式定义android:name属性。例如，指定读权限的com.example.app.provider.permission.READ\_PROVIDER。以下列表描述了提供程序权限的作用域，从适用于整个提供程序的权限开始，逐渐细化。相较于作用域较大的权限，越细化的权限拥有更高的优先级：
 
   - 统一的读写提供程序级权限
@@ -1833,7 +1836,7 @@ return (count);
 
 （7）定义访问权限
 
-内容提供器的访问权限在Manifest文件中声明\<provider\>时定义。默认状态下，所有的其他应用程序都可以访问这个内容提供器。
+内容提供器的访问权限在Manifest文件中声明\<provider\>时定义。建议显式声明 `android:exported`，不要依赖默认行为。通常情况下，仅应用内使用的提供器应设置为 `android:exported="false"`；需要跨应用共享时再设置为 `true`，并配合 `readPermission`/`writePermission` 或路径级权限。
 
 最后要在Manifest文件中注册内容提供器：
 
@@ -1841,7 +1844,9 @@ return (count);
 
 android:name=".StudentsProvider "
 
-android:authorities="com.androidbook.provider.StudentsProvider " /\>
+android:authorities="com.androidbook.provider.StudentsProvider"
+
+android:exported="false" /\>
 
 }
 
@@ -2019,6 +2024,8 @@ ListView是AdapterView的子类，用于列表显示。ListView的定义有两�
   - 继承ListActivity类，使用其内置的ListView对象。
 
   - 在布局文件中定义自定义视图的ListView。
+
+> 版本提示：`ListActivity` 已在 API 30 标记为弃用。新项目建议使用 `RecyclerView`（通常配合 `ListAdapter`/`DiffUtil`）；本节 `ListView` 与 `SimpleCursorAdapter` 示例主要用于理解内容提供器与游标绑定机制。
 
 ListActivity是一个专门显示ListView的Activity类，它内置了ListView对象，只要设置了数据源，就会自动地显示出来。虽然ListActivity内置了ListView对象，但依然可以在布局文件中自定义视图。自定义视图时，在布局文件中要注意设置ListView对象的id为"@id/android:list
 "；而在Java代码里使用android.R.id.list来引用ListView视图。在使用ListActivity来显示ListView视图时，如果使用了自定的布局文件，通过setContentView()方法进行绑定，如果不使用自定义的布局文件，这个步骤可以省略。安卓系统提供了多种模板进行选择，例如：


### PR DESCRIPTION
## 概述

更新第 8 章（`md/chapter08_content_providers.md`），使内容与当前 Android 开发指南保持一致。

## 主要变更

- 增加版本基线说明（Android 6.0+ 运行时权限、Android 12+ 组件导出规则）。
- 更新权限相关说明：
  - 明确 `normal` 与 `dangerous` 权限差异
  - 强调危险权限需在运行时申请
  - 将读取权限示例调整为 `READ_CONTACTS`
  - 补充 `READ_USER_DICTIONARY` 在 API 23+ 的适用范围说明
- 修正文档中的 `<provider>` 属性名为 `android:grantUriPermissions`。
- 将已过时的返回结果流程说明（`startActivityForResult` / `onActivityResult`）更新为 Activity Result API 建议。
- 补充 `ListActivity` 已弃用提示，并建议新项目使用 `RecyclerView`。

## 影响范围

仅文档更新，不涉及代码逻辑与运行时行为变更。
